### PR TITLE
fix edge case with {}'s in logs

### DIFF
--- a/src/FsLibLog/FsLibLog.fs
+++ b/src/FsLibLog/FsLibLog.fs
@@ -459,6 +459,10 @@ module Providers =
                           let value = sprintf "%A" propertyValue
                           msg <- msg.Replace(name, value)
 
+                        // it's possible for msg at this point to have what looks like format
+                        // specifiers, which will cause String.Format to puke
+                        let msg = msg.Replace("{", "{{").Replace("}", "}}")
+
                         // then c# numeric replacements
                         let msg = String.Format(CultureInfo.InvariantCulture, msg , formatParams)
 


### PR DESCRIPTION
## Proposed Changes

This fixes an edge case where it's possible for `writeMessage` to try to send a string to `String.Format` that looks like it still has format specifiers in it when there are none.

I haven't yet been able reproduce this with a toplevel test without reproducing the app I'm working ons environment, but here's a stack trace:

```
System.FormatException: Input string was not in a correct format.
   at System.Text.StringBuilder.FormatError()
   at System.Text.StringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ParamsArray args)                                                                                              
   at System.String.FormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.Format(IFormatProvider provider, String format, Object[] args)
   at A.B.Logging.Providers.ConsoleProvider.ConsoleProvider.writeMessage[a](a name, LogLevel logLevel, FSharpOption`1 messageFunc, FSharpOption`1 exception, Object[] formatParams) in /Users/jeremiahdodds/workspace/my/project/paket-files/TheAngryByrd/FsLibLog/src/FsLibLog/FsLibLog.fs:line 463
   at A.B.Logging.Providers.ConsoleProvider.A-B-Logging-Types-ILogProvider-GetLogger@487.Invoke(LogLevel logLevel, FSharpOption`1 messageFunc, FSharpOption`1 exception, Object[] formatParams) in /Users/jeremiahdodds/workspace/my/project/paket-files/TheAngryByrd/FsLibLog/src/FsLibLog/FsLibLog.fs:line 487                                                                                      
   at A.B.Logging.Types.Inner.ILog.fromLog(ILog logger, Log log) in /Users/jeremiahdodds/workspace/my/project/paket-files/TheAngryByrd/FsLibLog/src/FsLibLog/FsLibLog.fs:line 86                 
   at A.B.Logging.Types.Inner.ILog.error'(ILog logger, FSharpFunc`2 logConfig) in /Users/jeremiahdodds/workspace/my/project/paket-files/TheAngryByrd/FsLibLog/src/FsLibLog/FsLibLog.fs:line 126  
   at A.B.Logging.Types.Inner.ILog.error(ILog logger, FSharpFunc`2 logConfig) in /Users/jeremiahdodds/workspace/my/project/paket-files/TheAngryByrd/FsLibLog/src/FsLibLog/FsLibLog.fs:line 140   
   at <redacted>
   at FSharp.Control.Tasks.TaskBuilder.tryWith[a](FSharpFunc`2 step, FSharpFunc`2 catch)
```

The fix itself also might be done in a better way than two string replacements :/

## Types of changes

What types of changes does your code introduce to FsLibLog?
_Put an `x` in the boxes that apply_

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Tested via fsi calling `String.Format` on values as they appeared at runtime when I was seeing the error.