### PR TITLE
fix call to deprecated name

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Here is an example with FAKE 5:
 
 ```fsharp
 Target.create "Replace" <| fun _ ->
-  Shell.ReplaceInFiles
+  Shell.replaceInFiles
     [ "FsLibLog", "MyLib.Logging" ]
     (!! "paket-files/TheAngryByrd/FsLibLog/src/FsLibLog/FsLibLog.fs")
 ```


### PR DESCRIPTION
Fake deprecated `ReplaceInFiles` in favor of `replaceInFiles`. the old is still there, but gives a warning.

## Proposed Changes

Fix example calling deprecated method (change to method name casing only)

## Types of changes

What types of changes does your code introduce to FsLibLog?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] None of the above - Not a bug, not a feature, not breaking, just a documentation update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

