### PR TITLE
Fixes getLoggerByFunc for computation expressions

### DIFF
--- a/tests/FsLibLog.Tests/Tests.fs
+++ b/tests/FsLibLog.Tests/Tests.fs
@@ -70,6 +70,10 @@ let private getNewProvider () =
 let someFunction () =
     let logger = LogProvider.getLoggerByFunc()
     ()
+let someAsyncFunction () = async {
+    let logger = LogProvider.getLoggerByFunc()
+    ()
+}
 #endif
 
 type Dog = {
@@ -88,6 +92,11 @@ let tests =
                 let provider = getNewProvider()
                 someFunction()
                 Expect.equal provider.LoggerName "Tests.someFunction" ""
+            testCaseAsync "LogProvider.getLoggerByFunc async CE" <| async {
+                let provider = getNewProvider()
+                do! someAsyncFunction()
+                Expect.equal provider.LoggerName "Tests.someAsyncFunction" ""
+            }
 
             testCase "LogProvider.getLoggerByQuotation" <| fun _ ->
                 Expect.equal SomeOtherModule.provider.LoggerName "Tests+SomeOtherModule" ""


### PR DESCRIPTION
## Proposed Changes

Using `Reflection.MethodBase.GetCurrentMethod()` to try to get the current function name and where it’s located however I get odd results when I use them in computation expressions:

```fsharp
    let thingsToCall () =
        let mi = Reflection.MethodBase.GetCurrentMethod()
        printfn $"mi.DeclaringType.FullName : {mi.DeclaringType.FullName}"
        printfn $"mi.Name : {mi.Name}"
        // Output:
        // mi.DeclaringType.FullName : WebBackend.App
        // mi.Name : thingsToCall


    let thingsToCall2 () = async {
        let mi = Reflection.MethodBase.GetCurrentMethod()
        printfn $"mi.DeclaringType.FullName : {mi.DeclaringType.FullName}"
        printfn $"mi.Name : {mi.Name}"
        // Output:
        // mi.DeclaringType.FullName : WebBackend.App+thingsToCall2@130
        // mi.Name : Invoke

    }

    let thingsToCall3 () = task {
        let mi = Reflection.MethodBase.GetCurrentMethod()
        printfn $"mi.DeclaringType.FullName : {mi.DeclaringType.FullName}"
        printfn $"mi.Name : {mi.Name}"
        //Output:
        // mi.DeclaringType.FullName : WebBackend.App+thingsToCall3@135
        // mi.Name : MoveNext
    }
```

As you can see things aren't consistent.  [Using this current method for C# asyncs also exhibits this behavior](https://stackoverflow.com/questions/41153628/using-reflection-to-get-method-name-inside-an-async-method-does-not-return-expec).

To fix this, I've used a combination of `GetCurrentMethod` and `CallerMemberName`.

## Types of changes

What types of changes does your code introduce to FsLibLog?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
